### PR TITLE
Add OpenAPI docs and AWS deployment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,24 @@
-
 # Ecommerce Backend Skeleton
 
-Initial Express + TypeScript backend with Prisma and JWT auth.
-Phase 2 adds product, cart and order APIs with Stripe checkout.
+This project is an Express + TypeScript backend using Prisma and JWT authentication. It provides product, cart and order APIs with Stripe checkout support.
 
 ## Setup
 
-Create a `.env` file with `DATABASE_URL` and `JWT_SECRET` values.
-
-
-
-```bash
-npm install
-npx prisma migrate dev --name init # if you have access to DB
-npm run dev
-```
-
-
-### .env example
+Create a `.env` file with the following variables:
 
 ```bash
 DATABASE_URL=postgresql://user:pass@localhost:5432/db
 JWT_SECRET=supersecret
-STRIPE_SECRET=your_stripe_key
+STRIPE_SECRET_KEY=your_stripe_key
 ```
 
+Install dependencies and run the development server:
 
+```bash
+npm install
+npx prisma migrate dev --name init # if you have access to the DB
+npm run dev
+```
 
 Run tests:
 
@@ -33,20 +26,48 @@ Run tests:
 npm test
 ```
 
+## API Endpoints
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/health` | Health check |
+| POST | `/api/auth/signup` | Register a new user |
+| POST | `/api/auth/login` | Login and receive JWT |
+| GET | `/api/products` | List products |
+| GET | `/api/products/:id` | Get a single product |
+| POST | `/api/products` | Create product (admin) |
+| PUT | `/api/products/:id` | Update product (admin) |
+| DELETE | `/api/products/:id` | Delete product (admin) |
+| GET | `/api/cart` | View current cart (auth) |
+| POST | `/api/cart/add` | Add product to cart (auth) |
+| POST | `/api/cart/remove` | Remove product from cart (auth) |
+| POST | `/api/orders/checkout` | Checkout and create payment (auth) |
+| GET | `/api/orders` | View order history (auth) |
+
+Authenticated routes expect a `Bearer` token in the `Authorization` header.
+
+### OpenAPI
+
+A full OpenAPI specification can be found in [`docs/openapi.yaml`](docs/openapi.yaml). Tools like Swagger UI can be used to visualize the documentation.
+
 ## Docker
 
-Build and run the app together with a PostgreSQL database using Docker:
+Build and run the app together with a PostgreSQL database using Docker Compose:
 
 ```bash
 docker compose up --build
 ```
 
-The server will be available on `http://localhost:3000` and the database on port `5432`.
+The server will be available on `http://localhost:3000` and PostgreSQL on port `5432`.
 
+## AWS Deployment
 
+1. **ECS**: Build the Docker image using the provided `Dockerfile` and push it to ECR. Create an ECS service that runs the image.
+2. **RDS**: Provision a PostgreSQL database in Amazon RDS. Update `DATABASE_URL` to point to the RDS endpoint.
+3. **Environment Variables**: Configure the ECS task definition with `DATABASE_URL`, `JWT_SECRET` and `STRIPE_SECRET_KEY`.
+4. **Security Groups**: Allow inbound traffic from the load balancer to the ECS service on port 3000 and permit the ECS tasks to reach the RDS instance on port 5432.
+5. Optionally place an Application Load Balancer in front of the ECS service for HTTPS termination.
 
 # ecommerce
 
-This repository will contain the e-commerce project code.
-
-
+This repository contains the e-commerce project code.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,211 @@
+openapi: 3.0.3
+info:
+  title: Ecommerce API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        '200':
+          description: OK
+
+  /api/auth/signup:
+    post:
+      summary: Create a new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '201':
+          description: User created
+
+  /api/auth/login:
+    post:
+      summary: Authenticate a user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: JWT token
+
+  /api/products:
+    get:
+      summary: List products
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+        - in: query
+          name: search
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Product list
+    post:
+      summary: Create a product
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                price:
+                  type: number
+      responses:
+        '201':
+          description: Created
+
+  /api/products/{id}:
+    get:
+      summary: Get a product
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Product data
+    put:
+      summary: Update a product
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                price:
+                  type: number
+      responses:
+        '200':
+          description: Updated
+    delete:
+      summary: Delete a product
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Deleted
+
+  /api/cart:
+    get:
+      summary: View user's cart
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Cart items
+
+  /api/cart/add:
+    post:
+      summary: Add item to cart
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                productId:
+                  type: integer
+                quantity:
+                  type: integer
+      responses:
+        '200':
+          description: Item added
+
+  /api/cart/remove:
+    post:
+      summary: Remove item from cart
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                productId:
+                  type: integer
+      responses:
+        '200':
+          description: Item removed
+
+  /api/orders/checkout:
+    post:
+      summary: Checkout cart
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Stripe payment intent
+
+  /api/orders:
+    get:
+      summary: View order history
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Orders
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
## Summary
- document environment variables and API endpoints
- add detailed OpenAPI spec in `docs/openapi.yaml`
- include AWS deployment instructions for ECS and RDS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688cadb6eccc832f912bfdd8eb1b7d92