### PR TITLE
Fix duplicate health endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -21,7 +21,6 @@ app.use(morgan('dev'));
 app.use(express.json());
 
 // ✅ Health check
-app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 app.get('/health', (_req, res) => {
   res.status(200).json({ status: 'ok' });
 });


### PR DESCRIPTION
## Summary
- remove second `/health` handler so only one remains

## Testing
- `npm test` *(fails: Module '../middleware/auth' has no exported member 'requireAdmin')*

